### PR TITLE
Changed `created_at` to `run_started_at`. Applied isort for imports.

### DIFF
--- a/update_dashboard.py
+++ b/update_dashboard.py
@@ -1,9 +1,9 @@
-from datetime import datetime
-import requests
 import sys
-import yaml
+from datetime import datetime
 
 import pytz
+import requests
+import yaml
 
 
 class WorkflowData:
@@ -77,7 +77,7 @@ class WorkflowData:
             self.conclusion = self.status_code
 
     def get_run_time(self, last_run):
-        self.created_at = last_run["created_at"]
+        self.created_at = last_run["run_started_at"]
         self.updated_at = last_run["updated_at"]
 
         # Convert the timestamps to datetime objects


### PR DESCRIPTION
I looked through the documentation here (https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28#list-workflow-runs-for-a-repository--parameters) and stumbled across the `run_stated_at` field. 

I re-ran a smoke test in `rail_base` and was able to reproduce the behavior seen, and then double checked the json response that is provided from the github API and found the following: 

```
{
  "total_count": 144,
  "workflow_runs": [
    {
      "id": 6742131330,
      "name": "Unit test smoke test",
      ....
      "created_at": "2023-11-03T06:46:58Z",
      "updated_at": "2023-11-03T22:57:00Z",
      ....
      "run_attempt": 2,
      ....
      "run_started_at": "2023-11-03T22:54:44Z",
      ....
    },
    {
      "id": 6729227951,
      "name": "Unit test smoke test",
      ....
      "created_at": "2023-11-02T06:46:52Z",
      "updated_at": "2023-11-02T06:49:16Z",
       ....
      "run_attempt": 1,
      ....
      "run_started_at": "2023-11-02T06:46:52Z",
      ...
```

So I'm not 100% sure that using `run_started_at` is the correct fix to the problem, but in this case it seems to produce the correct output. 