### PR TITLE
Show stale state of workflow conclusion

### DIFF
--- a/html/css/styles.css
+++ b/html/css/styles.css
@@ -81,6 +81,11 @@ td.green-cell {
   font-weight: bold;
 }
 
+.gray-cell, .gray-cell>a {
+  color: rgb(181, 178, 136);
+  font-weight: bold;
+}
+
 /* Media query for larger viewports */
 @media (min-width: 1050px) {
   table {

--- a/src/lf_workflow_dash/data_types.py
+++ b/src/lf_workflow_dash/data_types.py
@@ -19,7 +19,7 @@ class WorkflowElemData:
     owner: str = ""
     repo: str = ""
     conclusion_time: str = ""
-    conclusion_date: str = ""
+    is_stale: bool = False
 
     def __init__(self, workflow_name, repo_url, owner, repo):
         self.workflow_name = workflow_name
@@ -30,24 +30,24 @@ class WorkflowElemData:
         self.display_class = "yellow-cell"
         self.icon_class = "fa fa-question-circle"
 
-    def set_status(self, status, conclusion_time):
+    def set_status(self, status, conclusion_time, is_stale):
         """Set the completion status of a workflow. This will also update the display class
         to suit the warning level.
 
         Args:
             status (str): how the workflow completed (e.g. "success" or "failure")
+            conclusion_time (str): pretty print of the conclusion of the last workflow run
+            is_stale (bool): if True, the last workflow run was a long time ago
         """
         self.workflow_status = status
         self.conclusion_time = conclusion_time
+        self.is_stale = is_stale
         if status == "success":
             self.display_class = "green-cell"
             self.icon_class = "fa fa-check-circle"
         elif status == "failure":
             self.display_class = "red-cell"
             self.icon_class = "fa fa-times-circle"
-        elif status == "stale":
-            self.display_class = "gray-cell"
-            self.icon_class = "fa fa-clock-o"
 
 
 @dataclass

--- a/src/lf_workflow_dash/data_types.py
+++ b/src/lf_workflow_dash/data_types.py
@@ -20,7 +20,6 @@ class WorkflowElemData:
     repo: str = ""
     conclusion_time: str = ""
     conclusion_date: str = ""
-    # TODO add is_stale
 
     def __init__(self, workflow_name, repo_url, owner, repo):
         self.workflow_name = workflow_name
@@ -30,27 +29,25 @@ class WorkflowElemData:
         self.workflow_status = "pending"
         self.display_class = "yellow-cell"
         self.icon_class = "fa fa-question-circle"
-        # TODO add is_stale
 
     def set_status(self, status, conclusion_time):
         """Set the completion status of a workflow. This will also update the display class
         to suit the warning level.
-
-        TODO update docstring to add is_stale logic
 
         Args:
             status (str): how the workflow completed (e.g. "success" or "failure")
         """
         self.workflow_status = status
         self.conclusion_time = conclusion_time
-        # TODO self.is_stale = is_stale
-        # TODO a nested branch here - first check if it's stale, and only if it isn't, check success
         if status == "success":
             self.display_class = "green-cell"
             self.icon_class = "fa fa-check-circle"
         elif status == "failure":
             self.display_class = "red-cell"
             self.icon_class = "fa fa-times-circle"
+        elif status == "stale":
+            self.display_class = "gray-cell"
+            self.icon_class = "fa fa-clock-o"
 
 
 @dataclass

--- a/src/lf_workflow_dash/github_request.py
+++ b/src/lf_workflow_dash/github_request.py
@@ -58,6 +58,7 @@ def update_workflow_status(workflow_elem, token):
     status_code = response.status_code
     conclusion = "pending"
     conclusion_time = ""
+    is_stale = False
 
     # Process data
     if status_code == 200:  # API was successful
@@ -73,8 +74,6 @@ def update_workflow_status(workflow_elem, token):
 
             # Get the time this workflow concluded (in New York time)
             (conclusion_time, is_stale) = get_conclusion_time(last_run)
-            if is_stale:
-                conclusion = "stale"
 
             # Check if the workflow is currently being executed
             if conclusion is None:
@@ -83,8 +82,6 @@ def update_workflow_status(workflow_elem, token):
                     last_run = response_json["workflow_runs"][1]
                     conclusion = last_run["conclusion"]
                     (conclusion_time, is_stale) = get_conclusion_time(last_run)
-                    if is_stale:
-                        conclusion = "stale"
                 else:
                     conclusion = "pending"
                     conclusion_time = ""
@@ -93,4 +90,4 @@ def update_workflow_status(workflow_elem, token):
         print("    ", status_code)
         conclusion = status_code
 
-    workflow_elem.set_status(conclusion, conclusion_time)
+    workflow_elem.set_status(conclusion, conclusion_time, is_stale)

--- a/templates/dash_template.jinja
+++ b/templates/dash_template.jinja
@@ -25,9 +25,15 @@
 
         <!-- Smoke Test -->
         <td class="{{project.smoke_test.display_class}} align-right">
+            {%- if project.smoke_test.is_stale %}
+            <span class="gray-cell">stale</span><br/>
+            {%- endif %}
             {{project.smoke_test.workflow_status}}
         </td>
         <td class="{{project.smoke_test.display_class}} align-center">
+            {%- if project.smoke_test.is_stale %}
+            <i class="gray-cell fa fa-clock-o"></i><br/>
+            {%- endif %}
             <i class="{{project.smoke_test.icon_class}}"></i>
         </td>
         <td class="{{project.smoke_test.display_class}}">
@@ -38,9 +44,15 @@
 
         <!-- Benchmarks -->
         <td class="{{project.benchmarks.display_class}} align-right">
+            {%- if project.benchmarks.is_stale %}
+            <span class="gray-cell">stale</span><br/>
+            {%- endif %}
             {{project.benchmarks.workflow_status}}
         </td>
         <td class="{{project.benchmarks.display_class}} align-center">
+            {%- if project.benchmarks.is_stale %}
+            <i class="gray-cell fa fa-clock-o"></i><br/>
+            {%- endif %}
             <i class="{{project.benchmarks.icon_class}}"></i>
         </td>
         <td class="{{project.benchmarks.display_class}}">
@@ -49,7 +61,7 @@
             </a>
         </td>
 
-        <!-- Build Docs -->
+        <!-- Build Docs (don't worry about is_stale here) -->
         <td class="{{project.build_docs.display_class}} align-right">
             {{project.build_docs.workflow_status}}
         </td>
@@ -64,9 +76,15 @@
 
         <!-- Live Build -->
         <td class="{{project.live_build.display_class}} align-right">
+            {%- if project.live_build.is_stale %}
+            <span class="gray-cell">stale</span><br/>
+            {%- endif %}
             {{project.live_build.workflow_status}}
         </td>
         <td class="{{project.live_build.display_class}} align-center">
+            {%- if project.live_build.is_stale %}
+            <i class="gray-cell fa fa-clock-o"></i><br/>
+            {%- endif %}
             <i class="{{project.live_build.icon_class}}"></i>
         </td>
         <td class="{{project.live_build.display_class}}">


### PR DESCRIPTION
For workflows that are more than 2 weeks old, give an additional "stale" indicator. 

![image](https://github.com/lincc-frameworks/lf-workflow-dash/assets/113376043/714b8dfe-cd5e-4b0c-aa5e-a0cf65fcd470)

While developing this feature, I was surprised how many workflows have gone stale! This dashboard is so useful!