### PR TITLE
Update gh-pages deployment step so it doesn't default to my account

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,3 +31,6 @@ jobs:
         with:
           branch: gh-pages
           folder: html
+          git-config-name: auto-deploy
+          git-config-email: <>
+          single-commit: true


### PR DESCRIPTION
Add missing keywords to gh-pages deployment; see readme here: https://github.com/JamesIves/github-pages-deploy-action/tree/dev

Will be followed up with a PR removing `single-commit: true` (once this has been run and removed the commit history that puts 90 commits a day on my account)